### PR TITLE
edit import path from github.com/Alluxio to github.com/alluxio

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	alluxio "github.com/Alluxio/alluxio-go"
-	"github.com/Alluxio/alluxio-go/option"
+	alluxio "github.com/alluxio/alluxio-go"
+	"github.com/alluxio/alluxio-go/option"
 )
 
 func metadataWorker(fs *alluxio.Client, path string) {

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/option"
 )
 
 func ExampleClient_download() {

--- a/option/create_directory.go
+++ b/option/create_directory.go
@@ -1,7 +1,7 @@
 package option
 
 import (
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // CreateDirectory holds the options for creating a directory.

--- a/option/create_file.go
+++ b/option/create_file.go
@@ -1,6 +1,6 @@
 package option
 
-import "github.com/Alluxio/alluxio-go/wire"
+import "github.com/alluxio/alluxio-go/wire"
 
 // CreateFile holds the options for creating a file.
 type CreateFile struct {

--- a/option/list_status.go
+++ b/option/list_status.go
@@ -1,7 +1,7 @@
 package option
 
 import (
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // ListStatus holds the options for listing a path.

--- a/option/open_file.go
+++ b/option/open_file.go
@@ -1,7 +1,7 @@
 package option
 
 import (
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // OpenFile holds the options for opening a file.

--- a/option/set_attribute.go
+++ b/option/set_attribute.go
@@ -1,6 +1,6 @@
 package option
 
-import "github.com/Alluxio/alluxio-go/wire"
+import "github.com/alluxio/alluxio-go/wire"
 
 // SetAttribute holds the options for setting path attributes.
 type SetAttribute struct {

--- a/optiontest/create_directory.go
+++ b/optiontest/create_directory.go
@@ -1,8 +1,8 @@
 package optiontest
 
 import (
-	"github.com/Alluxio/alluxio-go/option"
-	"github.com/Alluxio/alluxio-go/wiretest"
+	"github.com/alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/wiretest"
 )
 
 // RandomCreateDirectory creates a random instance of option.CreateDirectory.

--- a/optiontest/create_file.go
+++ b/optiontest/create_file.go
@@ -3,8 +3,8 @@ package optiontest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/option"
-	"github.com/Alluxio/alluxio-go/wiretest"
+	"github.com/alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/wiretest"
 )
 
 // RandomCreateFile creates a random instance of option.CreateFile.

--- a/optiontest/delete.go
+++ b/optiontest/delete.go
@@ -1,8 +1,8 @@
 package optiontest
 
 import (
-	"github.com/Alluxio/alluxio-go/option"
-	"github.com/Alluxio/alluxio-go/wiretest"
+	"github.com/alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/wiretest"
 )
 
 // RandomDelete creates a random instance of option.Delete.

--- a/optiontest/exists.go
+++ b/optiontest/exists.go
@@ -1,6 +1,6 @@
 package optiontest
 
-import "github.com/Alluxio/alluxio-go/option"
+import "github.com/alluxio/alluxio-go/option"
 
 // RandomExists creates a random instance of option.Exists.
 func RandomExists() option.Exists {

--- a/optiontest/free.go
+++ b/optiontest/free.go
@@ -1,8 +1,8 @@
 package optiontest
 
 import (
-	"github.com/Alluxio/alluxio-go/option"
-	"github.com/Alluxio/alluxio-go/wiretest"
+	"github.com/alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/wiretest"
 )
 
 // RandomFree creates a random instance of option.Free.

--- a/optiontest/get_status.go
+++ b/optiontest/get_status.go
@@ -1,6 +1,6 @@
 package optiontest
 
-import "github.com/Alluxio/alluxio-go/option"
+import "github.com/alluxio/alluxio-go/option"
 
 // RandomGetStatus creates a random instance of option.GetStatus.
 func RandomGetStatus() option.GetStatus {

--- a/optiontest/list_status.go
+++ b/optiontest/list_status.go
@@ -1,8 +1,8 @@
 package optiontest
 
 import (
-	"github.com/Alluxio/alluxio-go/option"
-	"github.com/Alluxio/alluxio-go/wiretest"
+	"github.com/alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/wiretest"
 )
 
 // RandomListStatus creates a random instance of option.ListStatus.

--- a/optiontest/mount.go
+++ b/optiontest/mount.go
@@ -3,8 +3,8 @@ package optiontest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/option"
-	"github.com/Alluxio/alluxio-go/wiretest"
+	"github.com/alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/wiretest"
 )
 
 // RandomMount creates a random instance of option.Mount.

--- a/optiontest/open_file.go
+++ b/optiontest/open_file.go
@@ -1,8 +1,8 @@
 package optiontest
 
 import (
-	"github.com/Alluxio/alluxio-go/option"
-	"github.com/Alluxio/alluxio-go/wiretest"
+	"github.com/alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/wiretest"
 )
 
 // RandomOpenFile creates a random instance of option.OpenFile.

--- a/optiontest/rename.go
+++ b/optiontest/rename.go
@@ -1,6 +1,6 @@
 package optiontest
 
-import "github.com/Alluxio/alluxio-go/option"
+import "github.com/alluxio/alluxio-go/option"
 
 // RandomRename creates a random instance of option.Rename.
 func RandomRename() option.Rename {

--- a/optiontest/set_attribute.go
+++ b/optiontest/set_attribute.go
@@ -3,8 +3,8 @@ package optiontest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/option"
-	"github.com/Alluxio/alluxio-go/wiretest"
+	"github.com/alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/wiretest"
 )
 
 // RandomSetAttribute creates a random instance of option.SetAttribute.

--- a/optiontest/unmount.go
+++ b/optiontest/unmount.go
@@ -1,6 +1,6 @@
 package optiontest
 
-import "github.com/Alluxio/alluxio-go/option"
+import "github.com/alluxio/alluxio-go/option"
 
 // RandomUnmount creates a random instance of option.Unmount.
 func RandomUnmount() option.Unmount {

--- a/paths.go
+++ b/paths.go
@@ -1,8 +1,8 @@
 package alluxio
 
 import (
-	"github.com/Alluxio/alluxio-go/option"
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 var (

--- a/paths_test.go
+++ b/paths_test.go
@@ -15,10 +15,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Alluxio/alluxio-go/option"
-	"github.com/Alluxio/alluxio-go/optiontest"
-	"github.com/Alluxio/alluxio-go/wire"
-	"github.com/Alluxio/alluxio-go/wiretest"
+	"github.com/alluxio/alluxio-go/option"
+	"github.com/alluxio/alluxio-go/optiontest"
+	"github.com/alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wiretest"
 )
 
 func init() {

--- a/wiretest/bits.go
+++ b/wiretest/bits.go
@@ -3,7 +3,7 @@ package wiretest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // RandomBits generates a random instace of wire.Bits.

--- a/wiretest/block_info.go
+++ b/wiretest/block_info.go
@@ -3,7 +3,7 @@ package wiretest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // RandomBlockInfo generates a random instance of wire.BlockInfo.

--- a/wiretest/block_location.go
+++ b/wiretest/block_location.go
@@ -3,7 +3,7 @@ package wiretest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // RandomBlockLocation generates a random instance of wire.BlockLocation.

--- a/wiretest/file_block_info.go
+++ b/wiretest/file_block_info.go
@@ -3,7 +3,7 @@ package wiretest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // RandomFileBlockInfo generates a random instance of wire.FileBlockInfo.

--- a/wiretest/file_info.go
+++ b/wiretest/file_info.go
@@ -3,7 +3,7 @@ package wiretest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // RandomFileInfo generates a random instance of wire.FileInfo.

--- a/wiretest/load_metadata_type.go
+++ b/wiretest/load_metadata_type.go
@@ -3,7 +3,7 @@ package wiretest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // RandomLoadMetadataType generates a random instance of wire.LoadMetadataType.

--- a/wiretest/mode.go
+++ b/wiretest/mode.go
@@ -1,6 +1,6 @@
 package wiretest
 
-import "github.com/Alluxio/alluxio-go/wire"
+import "github.com/alluxio/alluxio-go/wire"
 
 // RandomMode generates a random instance of wire.Mode.
 func RandomMode() wire.Mode {

--- a/wiretest/read_type.go
+++ b/wiretest/read_type.go
@@ -3,7 +3,7 @@ package wiretest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // RandomReadType generates a random instance of wire.ReadType.

--- a/wiretest/ttl_action.go
+++ b/wiretest/ttl_action.go
@@ -3,7 +3,7 @@ package wiretest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // RandomTTLAction generates a random instance of wire.TTLAction.

--- a/wiretest/worker_net_address.go
+++ b/wiretest/worker_net_address.go
@@ -3,7 +3,7 @@ package wiretest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // RandomWorkerNetAddress generates a random instance of wire.WorkerNetAddress.

--- a/wiretest/write_type.go
+++ b/wiretest/write_type.go
@@ -3,7 +3,7 @@ package wiretest
 import (
 	"math/rand"
 
-	"github.com/Alluxio/alluxio-go/wire"
+	"github.com/alluxio/alluxio-go/wire"
 )
 
 // RandomWriteType generates a random instance of wire.WriteType.


### PR DESCRIPTION
import paths should not have uppercase

this breaks any usages, requiring a rename of `"github.com/Alluxio/` -> `"github.com/alluxio/`